### PR TITLE
Tab Search Feature: Quickly Navigate Between Explorer Tabs

### DIFF
--- a/ExplorerTabUtility/Managers/HookManager.cs
+++ b/ExplorerTabUtility/Managers/HookManager.cs
@@ -1,12 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using ExplorerTabUtility.Helpers;
 using ExplorerTabUtility.Models;
 using ExplorerTabUtility.Hooks;
 using ExplorerTabUtility.WinAPI;
+using ExplorerTabUtility.UI.Views;
 
 namespace ExplorerTabUtility.Managers;
 
@@ -84,6 +85,10 @@ public sealed class HookManager
 
             case HotKeyAction.ToggleVisibility:
                 _syncContext.Post(_ => OnVisibilityToggled?.Invoke(), null);
+                break;
+
+            case HotKeyAction.TabSearch:
+                _syncContext.Post(_ => new TabSearchPopup(_windowHook).Show(), null);
                 break;
 
             case HotKeyAction.SnapRight:

--- a/ExplorerTabUtility/Models/HotKeyAction.cs
+++ b/ExplorerTabUtility/Models/HotKeyAction.cs
@@ -31,5 +31,7 @@ public enum HotKeyAction
     [Description("Snap the current window to the top.")]
     SnapUp,
     [Description("Snap the current window to the bottom.")]
-    SnapDown
+    SnapDown,
+    [Description("Open tab search popup to find and switch between tabs.")]
+    TabSearch
 }

--- a/ExplorerTabUtility/Models/WindowRecord.cs
+++ b/ExplorerTabUtility/Models/WindowRecord.cs
@@ -2,10 +2,13 @@
 
 namespace ExplorerTabUtility.Models;
 
-public class WindowRecord(string location, nint handle = 0, string[]? selectedItems = null)
+public class WindowRecord(string location, nint handle = 0, string[]? selectedItems = null, string name = "")
 {
     public nint Handle { get; set; } = handle;
+    public string Name { get; set; } = name;
     public string Location { get; set; } = location;
     public string[]? SelectedItems { get; set; } = selectedItems;
     public long CreatedAt { get; set; } = Environment.TickCount;
+
+    public string DisplayLocation => Location.Replace(@"file:\\\", "");
 }

--- a/ExplorerTabUtility/UI/Views/HotKeyProfileControl.xaml.cs
+++ b/ExplorerTabUtility/UI/Views/HotKeyProfileControl.xaml.cs
@@ -305,7 +305,8 @@ public partial class HotKeyProfileControl : UserControl
                 HotKeyAction.SnapRight,
                 HotKeyAction.SnapLeft,
                 HotKeyAction.SnapUp,
-                HotKeyAction.SnapDown
+                HotKeyAction.SnapDown,
+                HotKeyAction.TabSearch
             ],
             _ => Enum.GetValues(typeof(HotKeyAction))
                 .OfType<HotKeyAction>()

--- a/ExplorerTabUtility/UI/Views/TabSearchPopup.xaml
+++ b/ExplorerTabUtility/UI/Views/TabSearchPopup.xaml
@@ -1,0 +1,154 @@
+﻿<Window x:Class="ExplorerTabUtility.UI.Views.TabSearchPopup"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Height="450"
+        Width="600"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        Topmost="True"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStartupLocation="CenterScreen"
+        Deactivated="Window_Deactivated">
+
+    <Window.Resources>
+        <Style x:Key="TabItemStyle" TargetType="ListViewItem">
+            <Setter Property="Padding" Value="10,8" />
+            <Setter Property="Margin" Value="0,2" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ListViewItem}">
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="4"
+                                Padding="{TemplateBinding Padding}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+
+                                <!-- Icon -->
+                                <TextBlock Grid.Row="0" Grid.Column="0" Grid.RowSpan="2"
+                                           Text="&#xE2B4;"
+                                           FontSize="22"
+                                           Foreground="{StaticResource PrimaryLightBrush}"
+                                           VerticalAlignment="Center"
+                                           Margin="0,0,12,0" />
+
+                                <!-- Folder Name -->
+                                <TextBlock Grid.Row="0" Grid.Column="1"
+                                           Text="{Binding Name}"
+                                           FontWeight="Normal"
+                                           Foreground="{StaticResource TextAccentBrush}"
+                                           TextTrimming="CharacterEllipsis" />
+
+                                <!-- Path -->
+                                <TextBlock Grid.Row="1" Grid.Column="1"
+                                           Text="{Binding DisplayLocation}"
+                                           FontSize="12"
+                                           Foreground="{StaticResource TextTertiaryBrush}"
+                                           TextTrimming="CharacterEllipsis" />
+                            </Grid>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Border" Property="Background" Value="{StaticResource ControlBackgroundBrush}" />
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Border" Property="Background" Value="{StaticResource DropdownBackgroundBrush}" />
+                                <Setter TargetName="Border" Property="BorderBrush" Value="{StaticResource BorderGradientBrush}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+
+    <Border CornerRadius="8"
+            BorderThickness="1"
+            BorderBrush="{StaticResource BorderGradientBrush}"
+            Background="{StaticResource BackgroundGradientBrush}"
+            MouseLeftButtonDown="DragHandle_MouseLeftButtonDown">
+        <Border.Effect>
+            <DropShadowEffect Color="{StaticResource ShadowColor}"
+                              Direction="270"
+                              ShadowDepth="5"
+                              BlurRadius="15"
+                              Opacity="0.4" />
+        </Border.Effect>
+
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <!-- Search Box -->
+            <Border Grid.Row="0"
+                    Background="{StaticResource ControlBackgroundBrush}"
+                    BorderBrush="{StaticResource BorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Margin="15">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               Text="&#xE11A;"
+                               Foreground="{StaticResource BorderGradientBrush}"
+                               Margin="12,5,8,0"
+                               VerticalAlignment="Center" />
+
+                    <TextBox x:Name="SearchBox"
+                             Grid.Column="1"
+                             Margin="0,4"
+                             Padding="8,5"
+                             BorderThickness="0"
+                             FocusVisualStyle="{x:Null}"
+                             Background="Transparent"
+                             Foreground="{StaticResource AccentBrush}"
+                             FontFamily="{StaticResource DefaultFontFamily}"
+                             FontSize="{StaticResource DefaultFontSize}"
+                             ContextMenu="{StaticResource TextBoxCustomContextMenu}"
+                             CaretBrush="{StaticResource AccentBrush}"
+                             TextChanged="SearchBox_TextChanged"
+                             PreviewKeyDown="SearchBox_PreviewKeyDown" />
+                </Grid>
+            </Border>
+
+            <!-- Tab List -->
+            <ListView x:Name="TabsList"
+                      Grid.Row="1"
+                      Margin="15,0, 3, 15"
+                      BorderThickness="0"
+                      Background="Transparent"
+                      SelectionMode="Single"
+                      ItemContainerStyle="{StaticResource TabItemStyle}"
+                      ScrollViewer.VerticalScrollBarVisibility="Visible"
+                      ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+                      MouseLeftButtonUp="TabsList_MouseLeftButtonUp">
+                <ListView.Template>
+                    <ControlTemplate TargetType="{x:Type ListView}">
+                        <ScrollViewer Style="{StaticResource CustomScrollViewerStyle}">
+                            <ItemsPresenter />
+                        </ScrollViewer>
+                    </ControlTemplate>
+                </ListView.Template>
+            </ListView>
+        </Grid>
+    </Border>
+</Window>

--- a/ExplorerTabUtility/UI/Views/TabSearchPopup.xaml.cs
+++ b/ExplorerTabUtility/UI/Views/TabSearchPopup.xaml.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Controls;
+using System.Collections.Generic;
+using ExplorerTabUtility.Helpers;
+using ExplorerTabUtility.Models;
+using ExplorerTabUtility.Hooks;
+using Keyboard = System.Windows.Input.Keyboard;
+
+namespace ExplorerTabUtility.UI.Views;
+
+// ReSharper disable once RedundantExtendsListEntry
+public partial class TabSearchPopup : Window
+{
+    private bool _isClosing;
+    private readonly ExplorerWatcher _explorerWatcher;
+    private IReadOnlyCollection<WindowRecord> _allWindows = null!;
+    private IReadOnlyCollection<WindowRecord> _filteredWindows = null!;
+
+    public TabSearchPopup(ExplorerWatcher explorerWatcher)
+    {
+        InitializeComponent();
+
+        _explorerWatcher = explorerWatcher;
+
+        LoadWindows();
+        SearchBox.Focus();
+    }
+
+    private void LoadWindows()
+    {
+        _allWindows = _explorerWatcher.GetWindows();
+        _filteredWindows = _allWindows;
+        TabsList.ItemsSource = _filteredWindows;
+
+        if (_filteredWindows.Count > 0)
+            TabsList.SelectedIndex = 0;
+    }
+
+    private void FilterWindows(string searchText)
+    {
+        if (string.IsNullOrWhiteSpace(searchText))
+        {
+            _filteredWindows = _allWindows;
+        }
+        else
+        {
+            const StringComparison sc = StringComparison.OrdinalIgnoreCase;
+            _filteredWindows = _allWindows
+                .Where(w => w.Name.IndexOf(searchText, sc) != -1 || w.Location.IndexOf(searchText, sc) != -1)
+                .ToList();
+        }
+
+        TabsList.ItemsSource = _filteredWindows;
+
+        if (_filteredWindows.Count > 0)
+            TabsList.SelectedIndex = 0;
+    }
+
+    private void SelectNext()
+    {
+        if (_filteredWindows.Count == 0)
+            return;
+
+        if (TabsList.SelectedIndex < _filteredWindows.Count - 1)
+            TabsList.SelectedIndex++;
+        else
+            TabsList.SelectedIndex = 0; // Wrap around to the first item
+
+        TabsList.ScrollIntoView(TabsList.SelectedItem);
+    }
+
+    private void SelectPrevious()
+    {
+        if (_filteredWindows.Count == 0)
+            return;
+
+        if (TabsList.SelectedIndex > 0)
+            TabsList.SelectedIndex--;
+        else
+            TabsList.SelectedIndex = _filteredWindows.Count - 1; // Wrap around to the last item
+
+        TabsList.ScrollIntoView(TabsList.SelectedItem);
+    }
+
+    private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        FilterWindows(SearchBox.Text);
+    }
+
+    private void SearchBox_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Down)
+        {
+            SelectNext();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Up)
+        {
+            SelectPrevious();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Tab)
+        {
+            if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
+                SelectPrevious();
+            else
+                SelectNext();
+
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Enter && TabsList.SelectedItem != null)
+        {
+            SwitchToSelectedTab();
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            CloseWindow();
+            e.Handled = true;
+        }
+    }
+
+    private void Window_Deactivated(object sender, EventArgs e)
+    {
+        CloseWindow();
+    }
+
+    private void TabsList_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (TabsList.SelectedItem != null)
+            SwitchToSelectedTab();
+    }
+
+    private void DragHandle_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        DragMove();
+    }
+
+    private void SwitchToSelectedTab()
+    {
+        if (TabsList.SelectedItem is not WindowRecord selectedWindow)
+            return;
+
+        var asTab = true;
+        var duplicate = false;
+
+        // Check if SHIFT is pressed (open as new window)
+        if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
+            asTab = false;
+
+        // Check if CTRL is pressed (duplicate)
+        if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
+            duplicate = true;
+
+        _ = _explorerWatcher.SwitchTo(
+            selectedWindow.Location,
+            selectedWindow.Handle,
+            selectedWindow.SelectedItems,
+            asTab,
+            duplicate
+        );
+
+        CloseWindow();
+    }
+
+    private void CloseWindow()
+    {
+        if (_isClosing) return;
+        _isClosing = true;
+        Close();
+    }
+
+    public new void Show()
+    {
+        base.Show();
+        if (Activate()) return;
+
+        Helper.BypassWinForegroundRestrictions();
+        Activate();
+    }
+}


### PR DESCRIPTION
## Overview
This PR introduces a new Tab Search feature that allows users to quickly find, switch between, and manage Explorer tabs with a keyboard-focused interface. The feature enhances productivity by providing a fast way to navigate between multiple open locations without having to manually click through tabs.

## Features
- **Quick Tab Search**: Instantly search across all open tabs and recently closed locations
- **Keyboard Navigation**: Navigate search results with arrow keys and select with Enter
- **Modifier Key Support**:
    - Default: Switch to existing tab or open location in a new tab
    - SHIFT key: Open selected location in a new window instead of a tab
    - CTRL key: Duplicate the tab even if it already exists
- **Modern UI**: Clean, consistent design that matches the application's theme
- **Hotkey Integration**: Can be assigned to any keyboard or mouse combination via the profile system

## Implementation Details
- Added new `TabSearchPopup` window with search filtering capabilities
- Enhanced `ExplorerWatcher` to track and expose window/tab information
- Added `TabSearch` action to the `HotKeyAction` enum for hotkey binding
- Integrated with the `HookManager` to show the popup when triggered by hotkey

## Testing
- Tested with multiple open Explorer windows and tabs
- Verified search functionality with various folder paths and names
- Confirmed modifier key behaviors (SHIFT for new window, CTRL for duplication)
- Tested keyboard navigation and selection