### PR TITLE
fix: prevent ObjectDisposedException on shutdown (#82)

### DIFF
--- a/ExplorerTabUtility/ExplorerTabUtility.csproj
+++ b/ExplorerTabUtility/ExplorerTabUtility.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <UseWPF>True</UseWPF>
         <ApplicationIcon>Icon.ico</ApplicationIcon>
-        <Version>2.5.0</Version>
+        <Version>2.5.1</Version>
         <LangVersion>latest</LangVersion>
         <Title>Explorer Tab Utility</Title>
         <Authors>w4po</Authors>

--- a/ExplorerTabUtility/Hooks/ExplorerWatcher.cs
+++ b/ExplorerTabUtility/Hooks/ExplorerWatcher.cs
@@ -24,6 +24,7 @@ public class ExplorerWatcher : IHook
 {
     private static bool _instanceRunning;
     private static Guid _shellBrowserGuid = typeof(IShellBrowser).GUID;
+    private int _disposed;
 
     private ShellWindows _shellWindows = null!;
     private ShellPathComparer _shellPathComparer = null!;
@@ -931,6 +932,7 @@ public class ExplorerWatcher : IHook
     }
     private void DisposeShellObjects()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
         PersistWindows();
 
         // Unhook global event


### PR DESCRIPTION
## Summary
Fix `ObjectDisposedException` crash on system shutdown (fixes #82, #120, #123).

## Root Cause
During shutdown, `explorer.exe` terminates before the WPF application exits, causing `DisposeShellObjects()` to be called twice in a race condition:

1. **Route A** — `OnExplorerProcessTerminated()` → `DisposeShellObjects()`
2. **Route B** — WPF `Application.OnExit` → `ExplorerWatcher.Dispose()` → `DisposeShellObjects()`

On the second call, `StaTaskScheduler.Dispose()` calls `_tasks.CompleteAdding()` on an already-completed `BlockingCollection`, throwing `ObjectDisposedException`.

## Fix
Added a double-dispose guard to `DisposeShellObjects()` using `Interlocked.Exchange`:

```csharp
private int _disposed;

private void DisposeShellObjects()
{
    if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
    // ... existing code ...
}
```

## Verification
- Reproduced 100% of the time on shutdown before fix
- Crash dialog no longer appears after fix
- Tested on Windows 11, .NET 9, x64